### PR TITLE
O evento 'drop' nunca é chamado, devido ao comportamento padrão do navegador onde o evento 'dragover' substitui o 'drop'.

### DIFF
--- a/script.js
+++ b/script.js
@@ -38,7 +38,7 @@ function dragend() {
 /** place where we will drop cards */
 dropzones.forEach( dropzone => {
     dropzone.addEventListener('dragenter', dragenter)
-    dropzone.addEventListener('dragover', event => dragover(event))
+    dropzone.addEventListener('dragover', event => dragover(event, dropzone))
     dropzone.addEventListener('dragleave', dragleave)
     dropzone.addEventListener('drop', event => drop(event))
 })
@@ -47,16 +47,15 @@ function dragenter() {
     // log('DROPZONE: Enter in zone ')
 }
 
-function dragover(event) {
+function dragover(event, dropzone) {
     event.preventDefault()
     // this = dropzone
-    this.classList.add('over')
+    dropzone.classList.add('over')
 
     // get dragging card
     const cardBeingDragged = document.querySelector('.is-dragging')
-
     // this = dropzone
-    this.appendChild(cardBeingDragged)
+    dropzone.appendChild(cardBeingDragged)
 }
 
 function dragleave() {
@@ -69,5 +68,5 @@ function dragleave() {
 function drop(event) {
     event.preventDefault()
     // log('DROPZONE: dropped ')
-    this.classList.remove('over')
+    event.target.classList.remove('over')
 }

--- a/script.js
+++ b/script.js
@@ -38,16 +38,17 @@ function dragend() {
 /** place where we will drop cards */
 dropzones.forEach( dropzone => {
     dropzone.addEventListener('dragenter', dragenter)
-    dropzone.addEventListener('dragover', dragover)
+    dropzone.addEventListener('dragover', event => dragover(event))
     dropzone.addEventListener('dragleave', dragleave)
-    dropzone.addEventListener('drop', drop)
+    dropzone.addEventListener('drop', event => drop(event))
 })
 
 function dragenter() {
     // log('DROPZONE: Enter in zone ')
 }
 
-function dragover() {
+function dragover(event) {
+    event.preventDefault()
     // this = dropzone
     this.classList.add('over')
 
@@ -65,7 +66,8 @@ function dragleave() {
 
 }
 
-function drop() {
+function drop(event) {
+    event.preventDefault()
     // log('DROPZONE: dropped ')
     this.classList.remove('over')
 }


### PR DESCRIPTION
Olá! Acompanhando e posteriormente replicando o código do vídeo no youtube, percebi que a função drop não é utilizada, podendo ser até mesmo removida do código sem afetar em nada o resultado final da aplicação. A forma que encontrei de contornar isso foi prevenindo o comportamento padrão das funções 'drop' e 'dragover',  e as chamando dentro de uma arrow function para captar o evento. Após isso, necessitei passar o próprio 'dropzone' como parâmetro da função 'dragover' para substituir o 'this'.

Muito obrigado pelos vídeos, as aulas são sensacionais! Abraço.